### PR TITLE
Keep the full 30 s window and emit the straddling segment's start timestamp

### DIFF
--- a/src/whisper_prep/generation/data_processor.py
+++ b/src/whisper_prep/generation/data_processor.py
@@ -1027,6 +1027,21 @@ class DataProcessor:
 
                     prompt_buffer.append(new_prompt_node)
 
+                # An utterance that straddles the window edge contributes only its
+                # start timestamp, with no text and no end timestamp. Whisper uses
+                # this dangling token to decide where the next 30 s window begins
+                # (paper section 2.3: "For segments that are only partially included
+                # in the current 30-second window, we predict only their start time
+                # token ... to indicate that the subsequent decoding should be
+                # performed on an audio window aligned with that time").
+                if next_segment_start is not None:
+                    dangling_token = self._get_time_token(
+                        next_segment_start, segment_start, audio_path
+                    )
+                    segment_text.append(dangling_token)
+                    prompt_buffer.append(PromptNode(dangling_token, 1))
+                    tokens_length += 1
+
                 if tokens_length > self.max_tokens_length:
                     tqdm.write(
                         f"Skipping {audio_path} ({format_timestamp(segment_start / 1000)}-"
@@ -1036,14 +1051,11 @@ class DataProcessor:
                 elif not segment_utterances and random.random() >= self.keep_empty_chance:
                     pass
                 else:
-                    audio_segment_end = self._get_audio_segment_end(
-                        segment_utterances,
-                        segment_start,
-                        segment_end,
-                        next_segment_start,
-                    )
+                    # Always store the full window. Truncating at the last
+                    # complete utterance made every training sample end in silence,
+                    # which is not what the model sees at inference time.
                     segment_audio_path = self._save_segment_audio(
-                        audio, segment_start, audio_segment_end, dump_dir
+                        audio, segment_start, segment_end, dump_dir
                     )
                     empty_segment_failed_vad = (
                         not segment_utterances
@@ -1143,26 +1155,6 @@ class DataProcessor:
                 encoding="mp3",
             )
         return segment_audio_path
-
-    def _get_audio_segment_end(
-        self,
-        segment_utterances: List[Utterance],
-        segment_start: int,
-        segment_end: int,
-        next_segment_start: Optional[int],
-    ) -> int:
-        if next_segment_start is None:
-            return segment_end
-        if not segment_utterances:
-            return min(next_segment_start, segment_end)
-
-        rounded_utterance_end = max(
-            segment_start
-            + round((utterance.end - segment_start) / self.timestamp_resolution)
-            * self.timestamp_resolution
-            for utterance in segment_utterances
-        )
-        return min(max(next_segment_start, rounded_utterance_end), segment_end)
 
     @staticmethod
     def _merge_intervals(intervals: List[tuple]) -> List[tuple]:


### PR DESCRIPTION
## Summary

Long-form Whisper decoding advances its 30 s window by the last timestamp the decoder
predicts. Two details in `_create_records_with_timestamps` mean a model fine-tuned with
this pipeline never learns to predict that timestamp, so at inference the seeker skips
real audio at exact 30 s multiples.

1. **The saved audio was truncated at the last fully-contained utterance.**
   `_get_audio_segment_end()` returned
   `min(max(next_segment_start, rounded_utterance_end), segment_end)`, so whenever an
   utterance straddled the window edge the window was cut short and padded with silence.
   Every training sample therefore ended in silence. At inference the audio continues,
   which is out of distribution.

2. **The straddling utterance was dropped from the target entirely.** Whisper's
   convention (paper §2.3) is to emit its *start* timestamp with no text and no end
   timestamp:

   > "For segments that are only partially included in the current 30-second window, we
   > predict only their start time token when in timestamp mode, to indicate that the
   > subsequent decoding should be performed on an audio window aligned with that time."

   `jumon/whisper-finetuning`'s `create_data.py` implements exactly this
   (`else: segment_text.append(start_token)`), and always saves the full window.

## Why this is a fix and not a new feature

`Whisper-finetune`'s data loader is already written for this convention.
`data_loader.py::_get_partial_segment_start()` looks for **exactly two trailing timestamp
tokens** and `_calculate_mel()` cuts the mel there when `no_timestamps` is set. Because
this prep never emitted the dangling token, that code path was unreachable.

With the fix the two training modes compose correctly:

| mode | audio | target |
|---|---|---|
| timestamps (50%) | full 30 s | dangling start token retained — Whisper's convention |
| no timestamps (50%) | cut at the marker, zero-padded | timestamps stripped, so target matches what is audible |

## Evidence

Measured on LIEPA-3 `read` (985.67 h, 529,991 sentence clips), same config, only this
patch differing. 17,014 regenerated windows vs the previous run:

| metric | before | after |
|---|---|---|
| windows whose audio reaches >= 29.5 s | 15.5% | **78.1%** |
| windows carrying the dangling start token | **0%** | **68.2%** |
| mean window audio duration | 24.58 s | 27.13 s |
| segments per window | 3.85 | 3.90 |

`segments/window` is unchanged, confirming the transcribed content is identical — only
the audio extent and the resume marker differ.

### Confirmed in OpenAI's reference implementation

The clearest evidence comes from decoding with `openai-whisper` itself, since the
checkpoint is already in that format (`model_state_dict` + `dims`) and needs no
conversion. Sequential long-form decoding, `word_timestamps=True`, beam 5:

| | before the patch | after |
|---|---|---|
| segments filling the full 30 s window | ~74% | **0 of 425** |
| median segment length | — | 7.4 s (max 21.4 s) |
| holes on the exact 30 s grid | 23 of 34 | **0** |

Zero segments span the whole window. Segment lengths are natural subtitle spans again.
This is the original symptom that motivated the investigation, measured in the reference
decoder rather than a third-party reimplementation.

Three implementations agree on the same model and audio:

| implementation | alignment head pairs | words | zero-duration | holes | on-grid |
|---|---|---|---|---|---|
| `openai-whisper` | 320 | 6530 | 21 | 4 | **0** |
| `openai-whisper` | 10 curated | 6540 | 28 | 9 | **0** |
| `faster-whisper` | 320 | 6543 | 59 | 4 | **0** |
| `faster-whisper` | 10 curated | 6546 | 32 | 9 | **0** |
| `transformers` | 320 | 6516 | n/a* | n/a* | n/a* |
| `transformers` | 10 curated | 6516 | n/a* | n/a* | n/a* |

\* `transformers` `token_timestamps` are onsets, not spans, so zero-duration and hole
metrics are not defined for it. Its onset accuracy is consistent with the others once
its systematic late bias is removed.

Reference word timings throughout come from MMS CTC forced alignment (6547 words),
which is independent of Whisper.

### Result of retraining with the patch

`large-v3` fine-tuned twice on the identical corpus (985.67 h, 529,991 clips, 135,433
windows), same recipe and step count (1057 vs 1058), the packing patch the only
difference. Decoded with faster-whisper 1.2.1, beam 5, `word_timestamps=True`, on a
57-minute Lithuanian recording. Reference word timings from MMS CTC forced alignment
(6547 words, independent of Whisper).

| run | words | holes | **holes on the exact 30 s grid** | onset err <300 ms |
|---|---|---|---|---|
| `large-v3` baseline | 6346 | 50 | 4 (noise) | 80.4% |
| fine-tune, old packing | 6455 | 34 | **23** | 86.7% |
| fine-tune, old packing + `vad_filter` + `condition_on_previous_text=False` | 6509 | 19 | 8 | 87.3% |
| **fine-tune, patched packing** | **6543** | **4** | **0** | 86.8% |

The 30 s grid signature disappears completely. Word recovery reaches 6543 against the
6547-word reference. Note the patched model *without* any inference workaround beats the
unpatched model *with* one (4 holes / 0 on-grid vs 19 / 8), so this is a fix at the
source rather than a mitigation.

Before the patch, the entire first 30 s of correct text was stamped onto 1.16-1.26 s;
after it the opening is correctly timed (`4.38 šlapas`, `5.66 vakaras`, `6.14 visiems`).

### WER (reserved, speaker-disjoint sets)

| model | read | spon | fleurs |
|---|---|---|---|
| `large-v3` base | 28.99 | 24.08 | 24.37 |
| fine-tune, 0% timestamps | 8.85 | 13.43 | 14.93 |
| fine-tune, 50/50, old packing | 8.93 | **17.52** | 14.81 |
| fine-tune, 50/50, patched packing | 9.16 | **14.85** | 15.00 |

Training with timestamps under the old packing cost 4.09 points of spontaneous WER
(13.43 -> 17.52). The patch recovers 2.67 of those (-> 14.85) for +0.23 on read. So the
packing defect was not only breaking the seek, it was also degrading the transcript on
spontaneous speech.

Caveat: one run per condition.

### Independent confirmation of the mechanism

Distil-Whisper hit the same failure and fixed it the same way. From the
`distil-large-v3` model card:

> Previous Distil-Whisper models were trained on a mean input length of 7-seconds,
> whereas the original Whisper models were pre-trained on 30-second inputs. [...] the
> sequential long-form algorithm uses 30-second sliding windows for inference, with the
> window shifted according to the last predicted timestamp. Since the last timestamp
> typically occurs after the 15-second mark, it was predicted with low accuracy, causing
> the long-form transcription to often fail.

Their first listed remedy is "packing the audio samples in the training dataset to
30-seconds".

### Symptom detail

### Downstream symptom this explains

A `large-v3` fine-tune produced by this pipeline, decoded with faster-whisper 1.2.1
(beam 5, `word_timestamps=True`) on a 57-minute Lithuanian recording:

| model | words | zero-duration stamps | holes landing on the exact 30 s grid |
|---|---|---|---|
| `large-v3` baseline | 6346 | 9 | 4 / 50 (noise) |
| fine-tune | 6455 | 59 | **23 / 34, all at `0.00` mod 30** |

In the fine-tune the entire first 30 s of correct text is stamped onto 1.16–1.26 s,
followed by a hole to exactly 30.00. The baseline shows no such grid signature.

## Changes

- `_save_segment_audio(...)` is called with `segment_end`, so the whole window is stored.
- The straddling utterance's start timestamp is appended to `segment_text` and to the
  prompt buffer (1 token).
- `_get_audio_segment_end()` is removed — it has no remaining callers.

19 insertions, 27 deletions, one file.

## Related

`i4Ds/whisper-finetune#11` — `no_timestamp_training: true` silently short-circuits
`no_timestamp_rate`. That flag governs *whether* timestamps are trained; this patch
governs whether the timestamps that do get trained are learnable at the window edge.
