### PR TITLE
Fix VTT hour-less timestamps, dropped final subtitle, and stale prompt buffer

### DIFF
--- a/src/whisper_prep/generation/data_processor.py
+++ b/src/whisper_prep/generation/data_processor.py
@@ -722,7 +722,10 @@ class DataProcessor:
             lines = f.readlines()
             timestamps_indices = [i for i, line in enumerate(lines) if " --> " in line]
             timestamps_indices.append(
-                len(lines) + 1
+                # +2 so the final cue's text slice reaches the end of the file. With +1
+                # the last line is cut, which silently drops the last subtitle whenever
+                # the file does not end with a blank line.
+                len(lines) + 2
             )  # a dummy index to make the loop below simple
 
             for i in range(len(timestamps_indices) - 1):
@@ -796,7 +799,10 @@ class DataProcessor:
             lines = f.readlines()
             timestamps_indices = [i for i, line in enumerate(lines) if " --> " in line]
             timestamps_indices.append(
-                len(lines) + 1
+                # +2 so the final cue's text slice reaches the end of the file. With +1
+                # the last line is cut, which silently drops the last subtitle whenever
+                # the file does not end with a blank line.
+                len(lines) + 2
             )  # a dummy index to make the loop below simple
 
             for i in range(len(timestamps_indices) - 1):
@@ -980,6 +986,12 @@ class DataProcessor:
                     span_utterances[idx].start < segment_end
                     and span_utterances[idx].start + DURATION < span_utterances[idx].end
                 ):
+                    # The skipped utterance breaks the continuity of the transcript, so
+                    # the buffered prompt must not be carried into the following
+                    # segments -- the paper conditions on "the transcript text preceding
+                    # the current audio segment". The invalid-utterance skip path below
+                    # already clears it.
+                    prompt_buffer.clear()
                     segment_start = span_utterances[idx].end
                     idx += 1
                     continue
@@ -1257,7 +1269,19 @@ class DataProcessor:
             raise ValueError(
                 f"Invalid time format: {s}. Must be in the format of 00:00:00,000 or 00:00:00.000"
             )
-        hours, minutes, seconds = time.split(":")
+        parts = time.split(":")
+        if len(parts) == 3:
+            hours, minutes, seconds = parts
+        elif len(parts) == 2:
+            # WebVTT allows the hours field to be omitted, and Whisper's own WriteVTT
+            # emits MM:SS.mmm for anything under an hour (format_timestamp defaults to
+            # always_include_hours=False). Accept both.
+            hours, (minutes, seconds) = 0, parts
+        else:
+            raise ValueError(
+                f"Invalid time format: {s}. Must be HH:MM:SS or MM:SS, "
+                "separated from the milliseconds by ',' or '.'"
+            )
         hours = int(hours)
         minutes = int(minutes)
         seconds = int(seconds)


### PR DESCRIPTION
Three independent bugs in `data_processor.py`, all reachable from ordinary subtitle
input. Ported from [jumon/whisper-finetuning#33](https://github.com/jumon/whisper-finetuning/pull/33)
(merged 2026-07-02), which fixed the same three in the implementation this code follows.

Independent of [#6](https://github.com/i4Ds/whisper-prep/pull/6) — these can merge in either order.

## 1. `str_to_milliseconds` cannot parse `MM:SS.mmm`

It unpacks `time.split(":")` into three parts, assuming an `HH:MM:SS` field. But WebVTT
permits omitting the hours, and Whisper's own `WriteVTT` emits `MM:SS.mmm` for anything
under an hour (`format_timestamp` defaults to `always_include_hours=False`). Reading
such a file raises `ValueError: not enough values to unpack`.

This also blocks `read_utterances_from_vtt`, so VTT input is unusable for sub-hour
files produced by Whisper itself.

Verified after the fix:

| input | result |
|---|---|
| `00:01:24,331` | 84331 |
| `01:00:00,000` | 3600000 |
| `01:24.331` | 84331 |
| `00:00.500` | 500 |
| `1:2:3:4,000` | raises `ValueError` |

## 2. The final subtitle is silently dropped when a file has no trailing blank line

The text slice is `lines[utterance_start + 1 : next_utterance_start - 2]`, so the dummy
end index must be `len(lines) + 2` for the last cue's text to reach the end of the file.
With `+ 1` the last line is cut.

| final cue | `+1` (current) | `+2` (fixed) |
|---|---|---|
| single line, no trailing blank | `''` — **cue dropped by the `if not text: continue` guard** | `'LAST CUE'` |
| multi-line, no trailing blank | `'line A'` — **last line lost** | `'line A line B'` |
| any, with trailing blank line | unchanged | unchanged |

Files that do end with a blank line parse identically before and after, so this is
strictly a repair of the no-trailing-blank case. Both the SRT and VTT readers are
affected; both are fixed.

## 3. Skipping an utterance longer than 30 s leaves a stale prompt buffer

When an utterance is longer than the window it is skipped, but `prompt_buffer` keeps its
contents, so the following segments are conditioned on text that is not contiguous with
their audio. The paper conditions on "the transcript text preceding the current audio
segment", and the invalid-utterance skip path a few lines below already calls
`prompt_buffer.clear()`. This adds the same call to the over-long path.

## Impact

Low for pipelines that only consume self-generated SRTs — those end with a blank line,
use `HH:MM:SS`, and (with sentence-level sources) contain no cue over 30 s. I confirmed
0 occurrences of all three across 6400 cues in 400 generated files. The bugs bite on
*external* subtitle input, which `tsv_paths` / `source_transcript_dir` both allow.
